### PR TITLE
Integration of multiple render strategies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ tileLayer.render(batch);   // Render using a batch
 If you experience **texture bleeding**, adjust the inset tolerance:
 
 ```java
-tileLayer.setInsetTolerance(float xTolerance, float yTolerance);
+TileLayer.setInsetTolerance(float xTolerance, float yTolerance);
 ```
 
 This allows you to handle texture bleeding properly at runtime, without ever modifying your texture.
@@ -129,13 +129,29 @@ Suggested values:
 
 ### Custom Auto-Tile Configuration
 
-If your tile-set layout differs from the default, you can set a **custom auto-tile index mapping**:
+If your tile-set layout differs from the default, you can set a **custom auto-tile configuration**:
 
 ```java
-tileLayer.setAutoTileConfiguration(IntMap<Byte> customMapping);
+TileLayer.setAutoTileConfiguration(IntMap<Byte> configuration);
 ```
 
-*Note:* This is currently a **static property**, meaning it applies to all tile layers.
+*Note that this is currently a **static property**, meaning it applies to all tile layers.*
+
+### Rendering Strategies
+
+You may experiment with different `RenderStrategy` for your tilemap, there are 4 rendering strategies 
+integrated as of now:
+* `RenderStrategy.ALL_TILES_ALL_QUADS` will render all tiles and all quads.
+* `RenderStrategy.ALL_TILES_VIEW_QUADS` will render all tiles but only visible quads.
+* `RenderStrategy.VIEW_TILES_ALL_QUADS` will render visible tiles but all quads.
+* (default) `RenderStrategy.VIEW_TILES_VIEW_QUADS` will render visible tiles and only visible quads.
+
+*Visible quads are the ones associated with bitmask 0 in the auto-tile configuration.*
+
+You may change the current tile layer rendering strategy like this:
+```java
+tileLayer.setRenderStrategy(renderStrategy);
+```
 
 ### Serialization
 

--- a/example/src/main/java/me/nulldoubt/advancedtilemaps/example/AdvancedTilemapsExample.java
+++ b/example/src/main/java/me/nulldoubt/advancedtilemaps/example/AdvancedTilemapsExample.java
@@ -23,11 +23,7 @@ public class AdvancedTilemapsExample extends ApplicationAdapter {
     public static void main(String[] args) {
         if (StartupHelper.startNewJvmIfRequired())
             return; // This handles macOS support and helps on Windows.
-        createApplication();
-    }
-
-    private static Lwjgl3Application createApplication() {
-        return new Lwjgl3Application(new AdvancedTilemapsExample(), getDefaultConfiguration());
+        new Lwjgl3Application(new AdvancedTilemapsExample(), getDefaultConfiguration());
     }
 
     private static Lwjgl3ApplicationConfiguration getDefaultConfiguration() {
@@ -43,9 +39,11 @@ public class AdvancedTilemapsExample extends ApplicationAdapter {
     private static final String interfaceDebugInfo = """
         Rendered Tiles [CYAN](Dirt): %d[]
         Rendered Quads [CYAN](Dirt): %d[]
+        Render Strategy [CYAN](Dirt): %s[]
 
         Rendered Tiles [GREEN](Grass): %d[]
         Rendered Quads [GREEN](Grass): %d[]
+        Render Strategy [GREEN](Grass): %s[]
 
         Camera [YELLOW]Position: (%.2f, %.2f)[]
         Camera [YELLOW]Zoom: %.4f[]
@@ -315,8 +313,10 @@ public class AdvancedTilemapsExample extends ApplicationAdapter {
             interfaceDebugInfo,
             dirtLayer.getTilesRendered(),
             dirtLayer.getQuadsRendered(),
+            dirtLayer.getRenderStrategy(),
             grassLayer.getTilesRendered(),
             grassLayer.getQuadsRendered(),
+            grassLayer.getRenderStrategy(),
             worldCamera.position.x,
             worldCamera.position.y,
             worldCamera.zoom,


### PR DESCRIPTION
This PR allows the use of different rendering strategies.

Currently, there are 4 rendering strategies integrated directly into the `TileLayer` class.

The current rendering strategy may be set/get using the `setRenderStrategy()` and `getRenderStrategy()` methods respectively.